### PR TITLE
fix: fix cache problem

### DIFF
--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -836,8 +836,8 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 				if value, ok := response["pluginData"]; ok {
 					result.PluginData = value.(int)
 				}
-				if value, ok := response["cacheEnable"]; ok {
-					result.CacheEnable = value.(bool)
+				if value, ok := response["cacheDisable"]; ok {
+					result.CacheDisable = value.(bool)
 				}
 				if value, ok := response["errors"]; ok {
 					result.Errors = decodeMessages(value.([]interface{}))
@@ -911,8 +911,8 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 				if value, ok := response["pluginData"]; ok {
 					result.PluginData = value.(int)
 				}
-				if value, ok := response["cacheEnable"]; ok {
-					result.CacheEnable = value.(bool)
+				if value, ok := response["cacheDisable"]; ok {
+					result.CacheDisable = value.(bool)
 				}
 				if value, ok := response["errors"]; ok {
 					result.Errors = decodeMessages(value.([]interface{}))

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -731,10 +731,11 @@ func RunOnResolvePlugins(
 			}
 
 			var result config.OnResolveResult
-			key := resolverArgs.Importer.Text + "@@@" + resolverArgs.Path
+			key := resolverArgs.Importer.Text + "@@@" + resolverArgs.Path + "@@@" + resolverArgs.Importer.IgnoredSuffix +
+				"@@@" + resolverArgs.Importer.Namespace
 
 			resolveCacheRes := pluginCache.GetResolveCache(key)
-			if resolveCacheRes != nil && resolveCacheRes.CacheDisable {
+			if resolveCacheRes != nil && !resolveCacheRes.CacheDisable {
 				result = *resolveCacheRes
 			} else {
 				result = onResolve.Callback(resolverArgs)
@@ -875,15 +876,15 @@ func runOnLoadPlugins(
 					fsCache.ReadFile(fs, source.KeyPath.Text)
 				}
 				fsCache.ReadFile(fs, source.KeyPath.Text)
-
+				var key = loaderArgs.Path.Text + "@@@" + loaderArgs.Path.IgnoredSuffix
 				newContent := fsCache.GetCache(loaderArgs.Path.Text)
-				cacheRes := pluginCache.GetLoadCache(loaderArgs.Path.Text)
+				cacheRes := pluginCache.GetLoadCache(key)
 
-				if oldContent == newContent && cacheRes != nil && cacheRes.CacheDisable {
+				if oldContent == newContent && cacheRes != nil && !cacheRes.CacheDisable {
 					result = *cacheRes
 				} else {
 					result = onLoad.Callback(loaderArgs)
-					pluginCache.SetLoadCache(loaderArgs.Path.Text, &result)
+					pluginCache.SetLoadCache(key, &result)
 				}
 			} else {
 				result = onLoad.Callback(loaderArgs)
@@ -1073,7 +1074,6 @@ func ScanBundle(
 ) Bundle {
 	timer.Begin("Scan phase")
 	defer timer.End("Scan phase")
-	log.Add(logger.Warning, nil, logger.Range{}, fmt.Sprintf("hello world"))
 
 	applyOptionDefaults(&options)
 

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -734,7 +734,7 @@ func RunOnResolvePlugins(
 			key := resolverArgs.Importer.Text + "@@@" + resolverArgs.Path
 
 			resolveCacheRes := pluginCache.GetResolveCache(key)
-			if resolveCacheRes != nil && resolveCacheRes.CacheEnable {
+			if resolveCacheRes != nil && resolveCacheRes.CacheDisable {
 				result = *resolveCacheRes
 			} else {
 				result = onResolve.Callback(resolverArgs)
@@ -879,7 +879,7 @@ func runOnLoadPlugins(
 				newContent := fsCache.GetCache(loaderArgs.Path.Text)
 				cacheRes := pluginCache.GetLoadCache(loaderArgs.Path.Text)
 
-				if oldContent == newContent && cacheRes != nil && cacheRes.CacheEnable {
+				if oldContent == newContent && cacheRes != nil && cacheRes.CacheDisable {
 					result = *cacheRes
 				} else {
 					result = onLoad.Callback(loaderArgs)
@@ -1073,6 +1073,7 @@ func ScanBundle(
 ) Bundle {
 	timer.Begin("Scan phase")
 	defer timer.End("Scan phase")
+	log.Add(logger.Warning, nil, logger.Range{}, fmt.Sprintf("hello world"))
 
 	applyOptionDefaults(&options)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -591,7 +591,7 @@ type OnLoadResult struct {
 	Contents      *string
 	AbsResolveDir string
 	PluginData    interface{}
-	CacheDisable   bool
+	CacheDisable  bool
 
 	Msgs        []logger.Msg
 	ThrownError error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -565,8 +565,8 @@ type OnResolveResult struct {
 	AbsWatchFiles []string
 	AbsWatchDirs  []string
 
-	PluginData  interface{}
-	CacheEnable bool
+	PluginData   interface{}
+	CacheDisable bool
 
 	Path             logger.Path
 	External         bool
@@ -591,7 +591,7 @@ type OnLoadResult struct {
 	Contents      *string
 	AbsResolveDir string
 	PluginData    interface{}
-	CacheEnable   bool
+	CacheDisable   bool
 
 	Msgs        []logger.Msg
 	ThrownError error

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1162,10 +1162,10 @@ export function createChannel(streamIn: StreamIn): StreamOut {
                   "pluginData",
                   canBeAnything
                 );
-                let cacheEnable = getFlag(
+                let cacheDisable = getFlag(
                   result,
                   keys,
-                  "cacheEnable",
+                  "cacheDisable",
                   mustBeBoolean
                 );
                 let errors = getFlag(result, keys, "errors", mustBeArray);
@@ -1192,7 +1192,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
                 if (sideEffects != null) response.sideEffects = sideEffects;
                 if (pluginData != null)
                   response.pluginData = stash.store(pluginData);
-                if (cacheEnable != null) response.cacheEnable = cacheEnable;
+                if (cacheDisable != null) response.cacheDisable = cacheDisable;
                 if (errors != null)
                   response.errors = sanitizeMessages(
                     errors,
@@ -1284,10 +1284,10 @@ export function createChannel(streamIn: StreamIn): StreamOut {
                   "pluginData",
                   canBeAnything
                 );
-                let cacheEnable = getFlag(
+                let cacheDisable = getFlag(
                   result,
                   keys,
-                  "cacheEnable",
+                  "cacheDisable",
                   mustBeBoolean
                 );
                 let loader = getFlag(result, keys, "loader", mustBeString);
@@ -1315,7 +1315,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
                 if (resolveDir != null) response.resolveDir = resolveDir;
                 if (pluginData != null)
                   response.pluginData = stash.store(pluginData);
-                if (cacheEnable != null) response.cacheEnable = cacheEnable;
+                if (cacheDisable != null) response.cacheDisable = cacheDisable;
                 if (loader != null) response.loader = loader;
                 if (errors != null)
                   response.errors = sanitizeMessages(

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -202,7 +202,7 @@ export interface OnResolveResponse {
   suffix?: string;
   pluginData?: number;
 
-  cacheEnable?: boolean;
+  cacheDisable?: boolean;
 
   watchFiles?: string[];
   watchDirs?: string[];
@@ -230,7 +230,7 @@ export interface OnLoadResponse {
   loader?: string;
   pluginData?: number;
 
-  cacheEnable?: boolean;
+  cacheDisable?: boolean;
 
   watchFiles?: string[];
   watchDirs?: string[];

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -368,7 +368,7 @@ export interface OnResolveResult {
   suffix?: string;
   pluginData?: any;
 
-  cacheEnable?: boolean;
+  cacheDisable?: boolean;
 
   watchFiles?: string[];
   watchDirs?: string[];
@@ -397,7 +397,7 @@ export interface OnLoadResult {
   loader?: Loader;
   pluginData?: any;
 
-  cacheEnable?: boolean;
+  cacheDisable?: boolean;
   
   watchFiles?: string[];
   watchDirs?: string[];

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -536,12 +536,12 @@ type OnResolveResult struct {
 	Errors   []Message
 	Warnings []Message
 
-	Path        string
-	External    bool
-	SideEffects SideEffects
-	Namespace   string
-	Suffix      string
-	PluginData  interface{}
+	Path         string
+	External     bool
+	SideEffects  SideEffects
+	Namespace    string
+	Suffix       string
+	PluginData   interface{}
 	CacheDisable bool
 
 	WatchFiles []string
@@ -566,10 +566,10 @@ type OnLoadResult struct {
 	Errors   []Message
 	Warnings []Message
 
-	Contents    *string
-	ResolveDir  string
-	Loader      Loader
-	PluginData  interface{}
+	Contents     *string
+	ResolveDir   string
+	Loader       Loader
+	PluginData   interface{}
 	CacheDisable bool
 
 	WatchFiles []string

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -542,7 +542,7 @@ type OnResolveResult struct {
 	Namespace   string
 	Suffix      string
 	PluginData  interface{}
-	CacheEnable bool
+	CacheDisable bool
 
 	WatchFiles []string
 	WatchDirs  []string
@@ -570,7 +570,7 @@ type OnLoadResult struct {
 	ResolveDir  string
 	Loader      Loader
 	PluginData  interface{}
-	CacheEnable bool
+	CacheDisable bool
 
 	WatchFiles []string
 	WatchDirs  []string

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1639,7 +1639,7 @@ func (impl *pluginImpl) onResolve(options OnResolveOptions, callback func(OnReso
 				PluginData: args.PluginData,
 			})
 			result.PluginName = response.PluginName
-			result.CacheEnable = response.CacheEnable
+			result.CacheDisable = response.CacheDisable
 			result.AbsWatchFiles = impl.validatePathsArray(response.WatchFiles, "watch file")
 			result.AbsWatchDirs = impl.validatePathsArray(response.WatchDirs, "watch directory")
 
@@ -1693,7 +1693,7 @@ func (impl *pluginImpl) onLoad(options OnLoadOptions, callback func(OnLoadArgs) 
 				Suffix:     args.Path.IgnoredSuffix,
 			})
 			result.PluginName = response.PluginName
-			result.CacheEnable = response.CacheEnable
+			result.CacheDisable = response.CacheDisable
 			result.AbsWatchFiles = impl.validatePathsArray(response.WatchFiles, "watch file")
 			result.AbsWatchDirs = impl.validatePathsArray(response.WatchDirs, "watch directory")
 

--- a/test-site/plugin/load.ts
+++ b/test-site/plugin/load.ts
@@ -13,7 +13,7 @@ let loadPlugin: Plugin = {
         return {
           contents: content,
           loader: "tsx",
-          cacheEnable: true
+          cacheDisable: true
         }
       }
       return undefined

--- a/test-site/plugin/resolve.ts
+++ b/test-site/plugin/resolve.ts
@@ -10,7 +10,7 @@ let resolvePlugin: Plugin = {
         return {
           path: path.resolve(__dirname, "../src/index.tsx"),
           namespace: "file",
-          cacheEnable: true
+          cacheDisable: true
         }
       }
       return undefined;


### PR DESCRIPTION
目前实现存在两个bug
1. 默认CacheEnable为false，虽然在speedy-core里对js plugin的返回值都加了CacheEnable:true,但是对于esbuild内部的resolve结果返回值仍然是false，导致大量模块缓存失效
2. 计算resolve和load cache时，没将query也一起计算，导致同样的path不同的cache返回了同样的结果