### PR TITLE
fix: install link bin path error fixed

### DIFF
--- a/lib/npm/node-install.ts
+++ b/lib/npm/node-install.ts
@@ -223,7 +223,7 @@ async function checkAndPreparePackage(): Promise<void> {
   try {
     // First check for the binary package from our "optionalDependencies". This
     // package should have been installed alongside this package at install time.
-    binPath = require.resolve(`${pkg}/${subpath}`);
+    binPath = require.resolve(`@speedy-js/${pkg}/${subpath}`);
   } catch (e) {
     console.error(`[esbuild] Failed to find package "${pkg}" on the file system
 


### PR DESCRIPTION
past 

require resolve esbuild-darwin-arm64

now 

require resolve @speedy-js/esbuild-darwin-arm64