### PR TITLE
feat: code splitting support config min chunk size

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -66,6 +66,8 @@ var helpText = func(colors logger.Colors) string {
   --charset=utf8            Do not escape UTF-8 code points
   --chunk-names=...         Path template to use for code splitting chunks
                             (default "[name]-[hash]")
+  --min-chunk-size=...      Minimum chunk size in bytes, for a chunk to be generated.
+                            (default 0)
   --color=...               Force use of color terminal escapes (true | false)
   --drop:...                Remove certain constructs (console | debugger)
   --entry-names=...         Path template to use for entry point output paths

--- a/internal/bundler/bundler_splitting_test.go
+++ b/internal/bundler/bundler_splitting_test.go
@@ -525,3 +525,171 @@ func TestSplittingPublicPathEntryName(t *testing.T) {
 		},
 	})
 }
+
+func TestSplittingWithMinChunkSize0(t *testing.T) {
+	splitting_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/a.js": `
+				import { ab } from "./ab"
+        export default function main() {
+          ab()
+        }
+			`,
+			"/b.js": `
+				import { ab } from "./ab"
+        import { bc } from "./bc"
+        export default function main() {
+          ab()
+          bc()
+        }
+			`,
+			"/c.js": `
+        import { bc } from "./bc"
+        export default function main() {
+          bc()
+        }
+			`,
+			"/ab.js": `
+        import { abc } from "./abc"
+        export function ab() {
+          abc()
+          console.log(123)
+  				console.log("ab")
+        }
+			`,
+			"/bc.js": `
+        import { abc } from "./abc"
+        export function bc() {
+          abc()
+  				console.log("bc")
+        }
+			`,
+			"/abc.js": `
+        export function abc() {
+  				console.log("abc")
+        }
+      `,
+		},
+		entryPaths: []string{"/a.js", "/b.js", "/c.js"},
+		options: config.Options{
+			Mode:             config.ModeBundle,
+			CodeSplitting:    true,
+			MinifyWhitespace: true,
+			MinChunkSize:     0,
+			OutputFormat:     config.FormatESModule,
+			AbsOutputDir:     "/out",
+		},
+	})
+}
+
+func TestSplittingWithMinChunkSize100(t *testing.T) {
+	splitting_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/a.js": `
+				import { ab } from "./ab"
+        export default function main() {
+          ab()
+        }
+			`,
+			"/b.js": `
+				import { ab } from "./ab"
+        import { bc } from "./bc"
+        export default function main() {
+          ab()
+          bc()
+        }
+			`,
+			"/c.js": `
+        import { bc } from "./bc"
+        export default function main() {
+          bc()
+        }
+			`,
+			"/ab.js": `
+        import { abc } from "./abc"
+        export function ab() {
+          abc()
+          console.log(123)
+  				console.log("ab")
+        }
+			`,
+			"/bc.js": `
+        import { abc } from "./abc"
+        export function bc() {
+          abc()
+  				console.log("bc")
+        }
+			`,
+			"/abc.js": `
+        export function abc() {
+  				console.log("abc")
+        }
+      `,
+		},
+		entryPaths: []string{"/a.js", "/b.js", "/c.js"},
+		options: config.Options{
+			Mode:             config.ModeBundle,
+			CodeSplitting:    true,
+			MinifyWhitespace: true,
+			MinChunkSize:     100,
+			OutputFormat:     config.FormatESModule,
+			AbsOutputDir:     "/out",
+		},
+	})
+}
+
+func TestSplittingWithMinChunkSize200(t *testing.T) {
+	splitting_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/a.js": `
+				import { ab } from "./ab"
+        export default function main() {
+          ab()
+        }
+			`,
+			"/b.js": `
+				import { ab } from "./ab"
+        import { bc } from "./bc"
+        export default function main() {
+          ab()
+          bc()
+        }
+			`,
+			"/c.js": `
+        import { bc } from "./bc"
+        export default function main() {
+          bc()
+        }
+			`,
+			"/ab.js": `
+        import { abc } from "./abc"
+        export function ab() {
+          abc()
+          console.log(123)
+  				console.log("ab")
+        }
+			`,
+			"/bc.js": `
+        import { abc } from "./abc"
+        export function bc() {
+          abc()
+  				console.log("bc")
+        }
+			`,
+			"/abc.js": `
+        export function abc() {
+  				console.log("abc")
+        }
+      `,
+		},
+		entryPaths: []string{"/a.js", "/b.js", "/c.js"},
+		options: config.Options{
+			Mode:             config.ModeBundle,
+			CodeSplitting:    true,
+			MinifyWhitespace: true,
+			MinChunkSize:     200,
+			OutputFormat:     config.FormatESModule,
+			AbsOutputDir:     "/out",
+		},
+	})
+}

--- a/internal/bundler/snapshots/snapshots_splitting.txt
+++ b/internal/bundler/snapshots/snapshots_splitting.txt
@@ -570,6 +570,54 @@ export {
 };
 
 ================================================================================
+TestSplittingWithMinChunkSize0
+---------- /out/a.js ----------
+import{ab}from"./chunk-PPZCN2HQ.js";import"./chunk-QQUSMVXL.js";function main(){ab()}export{main as default};
+
+---------- /out/b.js ----------
+import{ab}from"./chunk-PPZCN2HQ.js";import{bc}from"./chunk-5EQD3PFI.js";import"./chunk-QQUSMVXL.js";function main(){ab();bc()}export{main as default};
+
+---------- /out/chunk-PPZCN2HQ.js ----------
+import{abc}from"./chunk-QQUSMVXL.js";function ab(){abc();console.log(123);console.log("ab")}export{ab};
+
+---------- /out/c.js ----------
+import{bc}from"./chunk-5EQD3PFI.js";import"./chunk-QQUSMVXL.js";function main(){bc()}export{main as default};
+
+---------- /out/chunk-5EQD3PFI.js ----------
+import{abc}from"./chunk-QQUSMVXL.js";function bc(){abc();console.log("bc")}export{bc};
+
+---------- /out/chunk-QQUSMVXL.js ----------
+function abc(){console.log("abc")}export{abc};
+
+================================================================================
+TestSplittingWithMinChunkSize100
+---------- /out/a.js ----------
+import{ab}from"./chunk-UZVVFJAB.js";import"./chunk-OFBQ4GHF.js";function abc(){console.log("abc")}function main(){ab()}export{main as default};
+
+---------- /out/b.js ----------
+import{ab}from"./chunk-UZVVFJAB.js";import{bc}from"./chunk-OFBQ4GHF.js";function main(){ab();bc()}export{main as default};
+
+---------- /out/chunk-UZVVFJAB.js ----------
+import{abc}from"./chunk-OFBQ4GHF.js";function ab(){abc();console.log(123);console.log("ab")}export{ab};
+
+---------- /out/c.js ----------
+import{bc}from"./chunk-OFBQ4GHF.js";function main(){bc()}export{main as default};
+
+---------- /out/chunk-OFBQ4GHF.js ----------
+function abc(){console.log("abc")}function bc(){abc();console.log("bc")}export{abc,bc};
+
+================================================================================
+TestSplittingWithMinChunkSize200
+---------- /out/a.js ----------
+function abc(){console.log("abc")}function ab(){abc();console.log(123);console.log("ab")}function main(){ab()}function bc(){abc();console.log("bc")}export{main as default};
+
+---------- /out/b.js ----------
+function abc(){console.log("abc")}function ab(){abc();console.log(123);console.log("ab")}function bc(){abc();console.log("bc")}function main(){ab();bc()}export{main as default};
+
+---------- /out/c.js ----------
+function abc(){console.log("abc")}function bc(){abc();console.log("bc")}function main(){bc()}function ab(){abc();console.log(123);console.log("ab")}export{main as default};
+
+================================================================================
 TestVarRelocatingBundle
 ---------- /out/top-level.js ----------
 // top-level.js

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -268,6 +268,7 @@ type Options struct {
 	MinifySyntax      bool
 	ProfilerNames     bool
 	CodeSplitting     bool
+	MinChunkSize      int
 	WatchMode         bool
 	Incremental       bool
 	ChangeFile        []string // extra add nodejs watch files about change

--- a/internal/helpers/bitset.go
+++ b/internal/helpers/bitset.go
@@ -18,10 +18,53 @@ func (bs BitSet) SetBit(bit uint) {
 	bs.entries[bit/8] |= 1 << (bit & 7)
 }
 
+func (bs BitSet) Subtract(other BitSet) {
+	if len(bs.entries) != len(other.entries) {
+		panic("subtract bitset must be same size")
+	}
+
+	for idx := range bs.entries {
+		bs.entries[idx] = bs.entries[idx] & (^other.entries[idx])
+	}
+}
+
+func (bs BitSet) Merge(other BitSet) {
+	if len(bs.entries) != len(other.entries) {
+		panic("subtract bitset must be same size")
+	}
+
+	for idx := range bs.entries {
+		bs.entries[idx] = bs.entries[idx] | other.entries[idx]
+	}
+}
+
+func (bs BitSet) Contains(other BitSet) bool {
+	if len(bs.entries) != len(other.entries) {
+		return false
+	}
+
+	for idx := range bs.entries {
+		curBs := bs.entries[idx]
+		curOther := other.entries[idx]
+		if (curBs^curOther)&curOther != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (bs BitSet) Equals(other BitSet) bool {
 	return bytes.Equal(bs.entries, other.entries)
 }
 
 func (bs BitSet) String() string {
 	return string(bs.entries)
+}
+
+func (bs BitSet) Clone() BitSet {
+	res := bs
+	res.entries = make([]byte, len(bs.entries))
+	copy(res.entries, bs.entries)
+	return res
 }

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1357,7 +1357,7 @@ type Symbol struct {
 	UseCountEstimate uint32
 
 	// This is for generating cross-chunk imports and exports for code splitting.
-	ChunkIndex ast.Index32
+	ChunkIndexs map[ast.Index32]bool
 
 	// This is used for minification. Symbols that are declared in sibling scopes
 	// can share a name. A good heuristic (from Google Closure Compiler) is to

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -225,6 +225,7 @@ function flagsForBuildOptions(
   let bundle = getFlag(options, keys, 'bundle', mustBeBoolean);
   let watch = getFlag(options, keys, 'watch', mustBeBooleanOrObject);
   let splitting = getFlag(options, keys, 'splitting', mustBeBoolean);
+  let minChunkSize = getFlag(options, keys, 'minChunkSize', mustBeInteger);
   let preserveSymlinks = getFlag(options, keys, 'preserveSymlinks', mustBeBoolean);
   let metafile = getFlag(options, keys, 'metafile', mustBeBoolean);
   let outfile = getFlag(options, keys, 'outfile', mustBeString);
@@ -271,6 +272,7 @@ function flagsForBuildOptions(
     }
   }
   if (splitting) flags.push('--splitting');
+  if (minChunkSize) flags.push(`--min-chunk-size=${minChunkSize}`);
   if (preserveSymlinks) flags.push('--preserve-symlinks');
   if (metafile) flags.push(`--metafile`);
   if (outfile) flags.push(`--outfile=${outfile}`);

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -78,6 +78,8 @@ export interface BuildOptions extends CommonOptions {
   bundle?: boolean;
   /** Documentation: https://esbuild.github.io/api/#splitting */
   splitting?: boolean;
+  /** Documentation: TODO */
+  minChunkSize?: number;
   /** Documentation: https://esbuild.github.io/api/#preserve-symlinks */
   preserveSymlinks?: boolean;
   /** Documentation: https://esbuild.github.io/api/#outfile */

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -320,9 +320,10 @@ type BuildOptions struct {
 	Footer            map[string]string // Documentation: https://esbuild.github.io/api/#footer
 	NodePaths         []string          // Documentation: https://esbuild.github.io/api/#node-paths
 
-	EntryNames string // Documentation: https://esbuild.github.io/api/#entry-names
-	ChunkNames string // Documentation: https://esbuild.github.io/api/#chunk-names
-	AssetNames string // Documentation: https://esbuild.github.io/api/#asset-names
+	EntryNames   string // Documentation: https://esbuild.github.io/api/#entry-names
+	ChunkNames   string // Documentation: https://esbuild.github.io/api/#chunk-names
+	MinChunkSize int    // Documentation: TODO
+	AssetNames   string // Documentation: https://esbuild.github.io/api/#asset-names
 
 	EntryPoints         []string     // Documentation: https://esbuild.github.io/api/#entry-points
 	EntryPointsAdvanced []EntryPoint // Documentation: https://esbuild.github.io/api/#entry-points

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -957,6 +957,7 @@ func rebuildImpl(
 		TreeShaking:           validateTreeShaking(buildOpts.TreeShaking, buildOpts.Bundle, buildOpts.Format),
 		GlobalName:            validateGlobalName(log, buildOpts.GlobalName),
 		CodeSplitting:         buildOpts.Splitting,
+		MinChunkSize:          buildOpts.MinChunkSize,
 		OutputFormat:          validateFormat(buildOpts.Format),
 		AbsOutputFile:         validatePath(log, realFS, buildOpts.Outfile, "outfile path"),
 		AbsOutputDir:          validatePath(log, realFS, buildOpts.Outdir, "outdir path"),
@@ -1801,13 +1802,6 @@ func loadPlugins(initialOptions *BuildOptions, fs fs.FS, log logger.Log, caches 
 			resolver := resolver.NewResolver(fs, log, caches, *buildOptions)
 
 			absResolveDir := validatePath(log, fs, options.ResolveDir, "resolve directory")
-			if log.HasErrors() {
-				msgs := log.Done()
-				result.Errors = convertMessagesToPublic(logger.Error, msgs)
-				result.Warnings = convertMessagesToPublic(logger.Warning, msgs)
-				return
-			}
-
 			if log.HasErrors() {
 				msgs := log.Done()
 				result.Errors = convertMessagesToPublic(logger.Error, msgs)

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -421,6 +421,17 @@ func parseOptionsImpl(
 		case strings.HasPrefix(arg, "--chunk-names=") && buildOpts != nil:
 			buildOpts.ChunkNames = arg[len("--chunk-names="):]
 
+		case strings.HasPrefix(arg, "--min-chunk-size=") && buildOpts != nil:
+			value := arg[len("--min-chunk-size="):]
+			size, err := strconv.Atoi(value)
+			if err != nil || size < 0 {
+				return parseOptionsExtras{}, cli_helpers.MakeErrorWithNote(
+					fmt.Sprintf("Invalid value %q in %q", value, arg),
+					"The min chunk size must be a non-negative integer.",
+				)
+			}
+			buildOpts.MinChunkSize = size
+
 		case strings.HasPrefix(arg, "--asset-names=") && buildOpts != nil:
 			buildOpts.AssetNames = arg[len("--asset-names="):]
 


### PR DESCRIPTION
### New CLI flags and API options:

* `--min-chunk-size` minimum chunk size in bytes, for a chunk to be generated.

### Details

* merge invalid chunk into other min chunk
* allow a import ref to map to multi chunk because one file may be in multi chunk
* generate imports & exports between chunks need to check dependencies(chunk.entryBits)

